### PR TITLE
Drop the NPM requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,9 +28,7 @@
     "meow": "^13.2.0"
   },
   "engines": {
-    "node": ">= 18",
-    "yarn": "use pnpm",
-    "npm": "use pnpm"
+    "node": ">= 18"
   },
   "files": [
     "index.js",


### PR DESCRIPTION
Having this field in engines means it can't be run from npx. Which is not the point. Dropping them.